### PR TITLE
Add static site builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+report/
+data/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,63 @@
 # VR_RacingClubTW
+
+This repository contains utilities for reading racing data from a public
+Google Spreadsheet and showing the processed results inside VRChat.
+
+## fetch_sheet.py
+
+`fetch_sheet.py` downloads the `歷史紀錄` worksheet from the public Google
+Spreadsheet identified by the ID `1ifyJiZfDAJD4kf-67puKALA2ikEHCSrnw02dvewdFO0`.
+The script exports the sheet as CSV and prints each row. It requires Python 3 and
+internet access. Run it with:
+
+```bash
+python3 fetch_sheet.py
+```
+
+If the environment blocks outbound network requests the script will fail with a
+`403 Forbidden` error.
+
+## generate_summary.py
+
+`generate_summary.py` builds a small text report from the spreadsheet data.
+The file `report/summary.txt` will be created containing a list of statistics.
+
+```bash
+python3 generate_summary.py
+```
+
+The script relies on `fetch_sheet.py` and therefore also requires internet
+access.
+
+## build_leaderboards.py
+
+`build_leaderboards.py` combines fetching the sheet, storing the raw CSV under
+`data/history.csv` and producing a simple text leaderboard at
+`data/leaderboard.txt`. The leaderboard lists the fastest driver for each
+track, best times per vehicle, each driver's career best and more. If a row is
+marked as belonging to a championship, it will be listed separately.
+
+Run it with:
+
+```bash
+python3 build_leaderboards.py
+```
+
+## prefab/TextDisplay.cs
+
+`prefab/TextDisplay.cs` is a simple Unity component that downloads a text file
+from a URL and displays it in a `Text` UI element. Attach it to a prefab and set
+the `url` and `targetText` fields in the Inspector.
+
+## build_site.py
+
+`build_site.py` reads the generated leaderboard text and creates a static
+`site/index.html` page. This page can be served via GitHub Pages so players can
+browse the latest results.
+
+```bash
+python3 build_site.py
+```
+
+After committing the contents of the `site` directory you can configure GitHub
+Pages to publish from that folder.

--- a/build_leaderboards.py
+++ b/build_leaderboards.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import csv
+import os
+from typing import Dict, List, Tuple
+
+from fetch_sheet import fetch_sheet
+
+# Directories for storing fetched data and reports
+DATA_DIR = "data"
+RAW_FILE = os.path.join(DATA_DIR, "history.csv")
+REPORT_FILE = os.path.join(DATA_DIR, "leaderboard.txt")
+
+
+def save_rows(rows: List[List[str]], path: str) -> None:
+    """Save the raw CSV rows to disk."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerows(rows)
+
+
+def parse_leaderboards(rows: List[List[str]]) -> List[str]:
+    """Compute various leaderboards from the data."""
+    if not rows:
+        return ["No data"]
+
+    header, *data = rows
+    # indices of relevant columns
+    try:
+        idx_track = header.index("賽道")
+        idx_driver = header.index("車手")
+        idx_vehicle = header.index("車輛")
+        idx_time = header.index("時間")
+    except ValueError:
+        return ["Missing required columns"]
+
+    idx_champ = header.index("錦標賽") if "錦標賽" in header else None
+
+    # Fastest time per track overall (driver)
+    fastest_by_track: Dict[str, Tuple[str, float]] = {}
+    # Fastest time per track per vehicle
+    fastest_by_track_vehicle: Dict[str, Dict[str, Tuple[str, float]]] = {}
+    # Driver career best
+    driver_best: Dict[str, float] = {}
+    # Vehicle best per track
+    vehicle_track_best: Dict[str, Dict[str, Tuple[str, float]]] = {}
+
+    championship_rows: List[List[str]] = []
+
+    for row in data:
+        if len(row) <= max(idx_track, idx_driver, idx_vehicle, idx_time):
+            continue
+        track = row[idx_track]
+        driver = row[idx_driver]
+        vehicle = row[idx_vehicle]
+        try:
+            t = float(row[idx_time])
+        except ValueError:
+            continue
+
+        if idx_champ is not None and row[idx_champ]:
+            championship_rows.append(row)
+
+        if track not in fastest_by_track or t < fastest_by_track[track][1]:
+            fastest_by_track[track] = (driver, t)
+
+        tbv = fastest_by_track_vehicle.setdefault(track, {})
+        if vehicle not in tbv or t < tbv[vehicle][1]:
+            tbv[vehicle] = (driver, t)
+
+        if driver not in driver_best or t < driver_best[driver]:
+            driver_best[driver] = t
+
+        vtb = vehicle_track_best.setdefault(vehicle, {})
+        if track not in vtb or t < vtb[track][1]:
+            vtb[track] = (driver, t)
+
+    lines: List[str] = []
+
+    lines.append("Fastest driver per track:")
+    for track, (driver, t) in fastest_by_track.items():
+        lines.append(f"{track}: {driver} {t}")
+
+    lines.append("")
+    lines.append("Fastest per vehicle on each track:")
+    for track, vehicles in fastest_by_track_vehicle.items():
+        lines.append(f"{track}:")
+        for vehicle, (driver, t) in vehicles.items():
+            lines.append(f"  {vehicle}: {driver} {t}")
+
+    lines.append("")
+    lines.append("Driver career best:")
+    for driver, t in driver_best.items():
+        lines.append(f"{driver}: {t}")
+
+    lines.append("")
+    lines.append("Vehicle best per track:")
+    for vehicle, tracks in vehicle_track_best.items():
+        lines.append(f"{vehicle}:")
+        for track, (driver, t) in tracks.items():
+            lines.append(f"  {track}: {driver} {t}")
+
+    if championship_rows:
+        lines.append("")
+        lines.append("Championship entries:")
+        for row in championship_rows:
+            lines.append(", ".join(row))
+
+    return lines
+
+
+def main() -> None:
+    try:
+        rows = fetch_sheet()
+    except Exception:
+        rows = []
+
+    if rows:
+        save_rows(rows, RAW_FILE)
+
+    report_lines = parse_leaderboards(rows)
+
+    os.makedirs(os.path.dirname(REPORT_FILE), exist_ok=True)
+    with open(REPORT_FILE, "w", encoding="utf-8") as fh:
+        for line in report_lines:
+            fh.write(line + "\n")
+
+    print(f"Leaderboard written to {REPORT_FILE}")
+
+
+if __name__ == "__main__":
+    main()

--- a/build_site.py
+++ b/build_site.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import os
+
+LEADERBOARD_FILE = os.path.join("data", "leaderboard.txt")
+OUTPUT_DIR = "site"
+OUTPUT_FILE = os.path.join(OUTPUT_DIR, "index.html")
+
+
+HTML_TEMPLATE = """<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+    <meta charset=\"UTF-8\">
+    <title>VR Racing Club Leaderboard</title>
+    <style>
+        body {{font-family: sans-serif; padding: 20px;}}
+        pre {{background: #f4f4f4; padding: 10px; white-space: pre-wrap;}}
+    </style>
+</head>
+<body>
+<h1>VR Racing Club Leaderboard</h1>
+<pre>{content}</pre>
+</body>
+</html>"""
+
+
+def build_page() -> None:
+    if os.path.exists(LEADERBOARD_FILE):
+        with open(LEADERBOARD_FILE, "r", encoding="utf-8") as fh:
+            content = fh.read()
+    else:
+        content = "No leaderboard data available."
+
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+    with open(OUTPUT_FILE, "w", encoding="utf-8") as fh:
+        fh.write(HTML_TEMPLATE.format(content=content))
+    print(f"Page written to {OUTPUT_FILE}")
+
+
+if __name__ == "__main__":
+    build_page()

--- a/fetch_sheet.py
+++ b/fetch_sheet.py
@@ -1,0 +1,55 @@
+"""Download racing data from a public Google Spreadsheet.
+
+This module exposes a :func:`fetch_sheet` function returning the CSV rows so
+other scripts can easily consume the data.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import urllib.parse
+import urllib.request
+from typing import List
+
+
+SHEET_ID = "1ifyJiZfDAJD4kf-67puKALA2ikEHCSrnw02dvewdFO0"
+"""Spreadsheet ID containing racing data."""
+
+SHEET_NAME = "歷史紀錄"
+"""Worksheet name with the historical records."""
+
+
+def fetch_sheet(sheet_id: str = SHEET_ID, sheet_name: str = SHEET_NAME) -> List[List[str]]:
+    """Return the worksheet contents as a list of rows.
+
+    Parameters
+    ----------
+    sheet_id:
+        The spreadsheet identifier.
+    sheet_name:
+        The specific worksheet name to download.
+    """
+
+    sheet_name_encoded = urllib.parse.quote(sheet_name)
+    url = (
+        f"https://docs.google.com/spreadsheets/d/{sheet_id}/gviz/tq?tqx=out:csv&sheet="
+        f"{sheet_name_encoded}"
+    )
+
+    print(f"Fetching data from: {url}")
+
+    try:
+        with urllib.request.urlopen(url) as response:
+            csv_data = response.read().decode("utf-8")
+    except Exception as e:  # pragma: no cover - network errors are environment specific
+        print("Failed to fetch data:", e)
+        raise
+
+    reader = csv.reader(io.StringIO(csv_data))
+    return list(reader)
+
+
+if __name__ == "__main__":
+    for row in fetch_sheet():
+        print(row)

--- a/generate_summary.py
+++ b/generate_summary.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import os
+from typing import List
+
+from fetch_sheet import fetch_sheet
+
+
+OUTPUT_DIR = "report"
+OUTPUT_FILE = os.path.join(OUTPUT_DIR, "summary.txt")
+
+
+def summarise(rows: List[List[str]]) -> List[str]:
+    if not rows:
+        return ["No data fetched."]
+
+    header, *data = rows
+    summary = [f"Total entries: {len(data)}"]
+
+    if "賽道" in header and "時間" in header:
+        track_idx = header.index("賽道")
+        time_idx = header.index("時間")
+        best_by_track: dict[str, float] = {}
+        for row in data:
+            if len(row) <= max(track_idx, time_idx):
+                continue
+            track = row[track_idx]
+            try:
+                t = float(row[time_idx])
+            except ValueError:
+                continue
+            if track not in best_by_track or t < best_by_track[track]:
+                best_by_track[track] = t
+        summary.append("Fastest per track:")
+        for track, t in best_by_track.items():
+            summary.append(f"{track}: {t}")
+    return summary
+
+
+def main() -> None:
+    try:
+        rows = fetch_sheet()
+    except Exception:
+        rows = []
+    lines = summarise(rows)
+
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+    with open(OUTPUT_FILE, "w", encoding="utf-8") as fh:
+        for line in lines:
+            fh.write(line + "\n")
+    print(f"Summary written to {OUTPUT_FILE}")
+
+
+if __name__ == "__main__":
+    main()

--- a/prefab/TextDisplay.cs
+++ b/prefab/TextDisplay.cs
@@ -1,0 +1,37 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.Networking;
+using UnityEngine.UI;
+
+public class TextDisplay : MonoBehaviour
+{
+    [Tooltip("URL of the summary text file")]
+    public string url;
+
+    [Tooltip("UI Text component to display the contents")]
+    public Text targetText;
+
+    private void Start()
+    {
+        if (!string.IsNullOrEmpty(url) && targetText != null)
+        {
+            StartCoroutine(DownloadText());
+        }
+    }
+
+    private IEnumerator DownloadText()
+    {
+        using (UnityWebRequest request = UnityWebRequest.Get(url))
+        {
+            yield return request.SendWebRequest();
+            if (request.result == UnityWebRequest.Result.Success)
+            {
+                targetText.text = request.downloadHandler.text;
+            }
+            else
+            {
+                targetText.text = "Failed to load";
+            }
+        }
+    }
+}

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>VR Racing Club Leaderboard</title>
+    <style>
+        body {font-family: sans-serif; padding: 20px;}
+        pre {background: #f4f4f4; padding: 10px; white-space: pre-wrap;}
+    </style>
+</head>
+<body>
+<h1>VR Racing Club Leaderboard</h1>
+<pre>No data
+</pre>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build Python script `build_site.py` to render the leaderboard as a static HTML page
- include generated `site/index.html` and usage notes in README

## Testing
- `python3 fetch_sheet.py` *(fails: Tunnel connection failed 403)*
- `python3 generate_summary.py` *(fails: Tunnel connection failed 403)*
- `python3 build_leaderboards.py` *(fails: Tunnel connection failed 403)*
- `python3 build_site.py`


------
https://chatgpt.com/codex/tasks/task_e_6876f4ba5640832dba7b56d358ff59e7