### PR TITLE
Add simple multi-tab GUI for world info

### DIFF
--- a/world_info/scraper/scraper.py
+++ b/world_info/scraper/scraper.py
@@ -3,15 +3,16 @@
 
 This script queries the unofficial VRChat API to fetch world information
 and stores the results as a JSON list.  Authentication headers such as
-cookies should be provided in ``headers.json``.  The file is ignored by
-git so your credentials remain local.
+cookies can be supplied in ``headers.json`` or via command line options.
+The credentials file is ignored by git so your secrets remain local.
 """
 
 from __future__ import annotations
 
+import base64
 import json
 from pathlib import Path
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable, List, Optional
 import time
 
 import requests
@@ -20,25 +21,42 @@ BASE = Path(__file__).parent
 HEADERS_FILE = BASE / "headers.json"
 
 
-def _load_headers() -> Dict[str, str]:
-    """Load HTTP headers from ``headers.json`` if it exists."""
+def _load_headers(cookie: Optional[str] = None,
+                  username: Optional[str] = None,
+                  password: Optional[str] = None) -> Dict[str, str]:
+    """Load HTTP headers from ``headers.json`` and command line options."""
+
+    headers = {"User-Agent": "Mozilla/5.0"}
+
     if HEADERS_FILE.exists():
         with open(HEADERS_FILE, "r", encoding="utf-8") as f:
-            return json.load(f)
-    return {"User-Agent": "Mozilla/5.0"}
+            try:
+                headers.update(json.load(f))
+            except json.JSONDecodeError:
+                pass
+
+    if cookie:
+        headers["Cookie"] = cookie
+
+    if username and password:
+        token = base64.b64encode(f"{username}:{password}".encode()).decode()
+        headers["Authorization"] = f"Basic {token}"
+
+    return headers
 
 
-HEADERS = _load_headers()
+HEADERS: Dict[str, str] = _load_headers()
 
 
-def _fetch_paginated(base_url: str, limit: int, delay: float) -> List[dict]:
+def _fetch_paginated(base_url: str, limit: int, delay: float,
+                     headers: Optional[Dict[str, str]] = None) -> List[dict]:
     """Fetch up to ``limit`` worlds from ``base_url`` using pagination."""
     results: List[dict] = []
     offset = 0
     while len(results) < limit:
         remaining = min(60, limit - len(results))
         url = f"{base_url}&n={remaining}&offset={offset}"
-        r = requests.get(url, headers=HEADERS, timeout=30)
+        r = requests.get(url, headers=headers or HEADERS, timeout=30)
         r.raise_for_status()
         chunk = r.json()
         if not isinstance(chunk, list):
@@ -51,14 +69,16 @@ def _fetch_paginated(base_url: str, limit: int, delay: float) -> List[dict]:
     return results[:limit]
 
 
-def search_worlds(keyword: str, limit: int = 20, delay: float = 1.0) -> List[dict]:
+def search_worlds(keyword: str, limit: int = 20, delay: float = 1.0,
+                  headers: Optional[Dict[str, str]] = None) -> List[dict]:
     base = f"https://api.vrchat.cloud/api/1/worlds?search={keyword}"
-    return _fetch_paginated(base, limit, delay)
+    return _fetch_paginated(base, limit, delay, headers)
 
 
-def get_user_worlds(user_id: str, limit: int = 20, delay: float = 1.0) -> List[dict]:
+def get_user_worlds(user_id: str, limit: int = 20, delay: float = 1.0,
+                    headers: Optional[Dict[str, str]] = None) -> List[dict]:
     base = f"https://api.vrchat.cloud/api/1/users/{user_id}/worlds?"
-    return _fetch_paginated(base, limit, delay)
+    return _fetch_paginated(base, limit, delay, headers)
 
 
 def extract_info(world: dict) -> Dict[str, object]:
@@ -80,6 +100,20 @@ def extract_info(world: dict) -> Dict[str, object]:
     }
 
 
+def fetch_worlds(*,
+                 keyword: Optional[str] = None,
+                 user_id: Optional[str] = None,
+                 limit: int = 20,
+                 delay: float = 1.0,
+                 headers: Optional[Dict[str, str]] = None) -> List[dict]:
+    """High level helper to fetch worlds by keyword or user ID."""
+    if keyword:
+        return search_worlds(keyword, limit, delay, headers)
+    if user_id:
+        return get_user_worlds(user_id, limit, delay, headers)
+    raise ValueError("keyword or user_id required")
+
+
 def main() -> None:
     import argparse
 
@@ -89,12 +123,18 @@ def main() -> None:
     parser.add_argument("--limit", type=int, default=20, help="maximum worlds")
     parser.add_argument("--delay", type=float, default=1.0, help="seconds between requests")
     parser.add_argument("--out", type=Path, default=BASE / "raw_worlds.json", help="output JSON path")
+    parser.add_argument("--cookie", help="authentication cookie string")
+    parser.add_argument("--username", help="basic auth username")
+    parser.add_argument("--password", help="basic auth password")
     args = parser.parse_args()
 
+    global HEADERS
+    HEADERS = _load_headers(args.cookie, args.username, args.password)
+
     if args.keyword:
-        worlds = search_worlds(args.keyword, args.limit, args.delay)
+        worlds = search_worlds(args.keyword, args.limit, args.delay, HEADERS)
     elif args.user:
-        worlds = get_user_worlds(args.user, args.limit, args.delay)
+        worlds = get_user_worlds(args.user, args.limit, args.delay, HEADERS)
     else:
         parser.error("--keyword or --user is required")
 

--- a/world_info/ui.py
+++ b/world_info/ui.py
@@ -1,99 +1,204 @@
+"""Tkinter GUI for fetching and filtering VRChat world data.
+
+The interface provides several tabs:
+- Entrance: input authentication (cookie or basic auth), a search keyword
+  and creator user ID.
+- Data: fetch worlds by keyword and display the raw JSON.
+- Filter: filter the keyword results by tag and sort order.
+- World List: show the filtered worlds in a simple list.
+- User Worlds: fetch and display worlds created by a specific user.
+
+The tool relies on functions in ``scraper/scraper.py``.  Results are saved
+under that folder for reuse by other scripts.
+"""
+from __future__ import annotations
+
 import json
 from pathlib import Path
 import tkinter as tk
 from tkinter import ttk, messagebox
 
+from scraper.scraper import fetch_worlds, _load_headers
+
 BASE = Path(__file__).resolve().parent
-RAW_FILE = BASE / 'scraper' / 'raw_worlds.json'
-REVIEW_FILE = BASE / 'scraper' / 'reviewed_worlds.json'
+RAW_FILE = BASE / "scraper" / "raw_worlds.json"
+USER_FILE = BASE / "scraper" / "user_worlds.json"
 
 
-class ReviewUI(tk.Tk):
+class WorldInfoUI(tk.Tk):
     def __init__(self) -> None:
         super().__init__()
-        self.title('World Review')
-        self.geometry('600x400')
-        self.worlds = self._load_worlds()
-        self.reviews = self._load_reviews()
-        self.index = 0
-        self._build_widgets()
-        self._show_world()
+        self.title("World Info")
+        self.geometry("800x600")
 
-    def _load_worlds(self):
-        if RAW_FILE.exists():
-            with open(RAW_FILE, 'r', encoding='utf-8') as f:
-                return json.load(f)
-        messagebox.showerror('Error', f'Missing {RAW_FILE}')
-        return []
+        self.headers = {}
+        self.data: list[dict] = []
+        self.user_data: list[dict] = []
+        self.filtered: list[dict] = []
 
-    def _load_reviews(self):
-        if REVIEW_FILE.exists():
-            with open(REVIEW_FILE, 'r', encoding='utf-8') as f:
-                return json.load(f)
-        return {}
+        self._build_tabs()
 
-    def _build_widgets(self) -> None:
-        self.label_name = ttk.Label(self, text='', font=('Arial', 14))
-        self.label_name.pack(pady=4)
-        self.text_desc = tk.Text(self, height=10, wrap='word')
-        self.text_desc.pack(fill=tk.BOTH, expand=True, padx=5)
-        frame = ttk.Frame(self)
-        frame.pack(pady=4)
-        ttk.Button(frame, text='Approve', command=self._approve).grid(row=0, column=0, padx=2)
-        ttk.Button(frame, text='Reject', command=self._reject).grid(row=0, column=1, padx=2)
-        ttk.Button(frame, text='Skip', command=self._next).grid(row=0, column=2, padx=2)
-        self.status_label = ttk.Label(frame, text='')
-        self.status_label.grid(row=0, column=3, padx=10)
+    # ------------------------------------------------------------------
+    # UI construction
+    def _build_tabs(self) -> None:
+        self.nb = ttk.Notebook(self)
+        self.nb.pack(fill=tk.BOTH, expand=True)
 
-    def _show_world(self) -> None:
-        if self.index >= len(self.worlds):
-            messagebox.showinfo('Review', 'No more worlds')
-            self.label_name.config(text='')
-            self.text_desc.delete('1.0', tk.END)
-            self.status_label.config(text='')
+        self.tab_entry = ttk.Frame(self.nb)
+        self.tab_data = ttk.Frame(self.nb)
+        self.tab_filter = ttk.Frame(self.nb)
+        self.tab_list = ttk.Frame(self.nb)
+        self.tab_user = ttk.Frame(self.nb)
+
+        self.nb.add(self.tab_entry, text="入口")
+        self.nb.add(self.tab_data, text="資料")
+        self.nb.add(self.tab_filter, text="篩選")
+        self.nb.add(self.tab_list, text="世界列表")
+        self.nb.add(self.tab_user, text="個人世界")
+
+        self._build_entry_tab()
+        self._build_data_tab()
+        self._build_filter_tab()
+        self._build_list_tab()
+        self._build_user_tab()
+
+    # ------------------------------------------------------------------
+    # Entry tab widgets
+    def _build_entry_tab(self) -> None:
+        f = self.tab_entry
+        row = 0
+        ttk.Label(f, text="Cookie").grid(row=row, column=0, sticky="e")
+        self.var_cookie = tk.StringVar()
+        tk.Entry(f, textvariable=self.var_cookie, width=60).grid(row=row, column=1, padx=4, pady=2)
+        row += 1
+
+        ttk.Label(f, text="Username").grid(row=row, column=0, sticky="e")
+        self.var_user = tk.StringVar()
+        tk.Entry(f, textvariable=self.var_user).grid(row=row, column=1, padx=4, pady=2)
+        row += 1
+
+        ttk.Label(f, text="Password").grid(row=row, column=0, sticky="e")
+        self.var_pass = tk.StringVar()
+        tk.Entry(f, textvariable=self.var_pass, show="*").grid(row=row, column=1, padx=4, pady=2)
+        row += 1
+
+        ttk.Label(f, text="Search Keyword").grid(row=row, column=0, sticky="e")
+        self.var_keyword = tk.StringVar()
+        tk.Entry(f, textvariable=self.var_keyword).grid(row=row, column=1, padx=4, pady=2)
+        row += 1
+
+        ttk.Label(f, text="User ID").grid(row=row, column=0, sticky="e")
+        self.var_userid = tk.StringVar()
+        tk.Entry(f, textvariable=self.var_userid).grid(row=row, column=1, padx=4, pady=2)
+        row += 1
+
+        btn_frame = ttk.Frame(f)
+        btn_frame.grid(row=row, column=0, columnspan=2, pady=4)
+        ttk.Button(btn_frame, text="Search", command=self._on_search).grid(row=0, column=0, padx=2)
+        ttk.Button(btn_frame, text="User Worlds", command=self._on_user).grid(row=0, column=1, padx=2)
+
+    # ------------------------------------------------------------------
+    # Data tab widgets
+    def _build_data_tab(self) -> None:
+        self.text_data = tk.Text(self.tab_data, wrap="word")
+        self.text_data.pack(fill=tk.BOTH, expand=True)
+        ttk.Button(self.tab_data, text="Open Filter", command=lambda: self.nb.select(self.tab_filter)).pack(pady=4)
+
+    # Filter tab widgets
+    def _build_filter_tab(self) -> None:
+        f = self.tab_filter
+        ttk.Label(f, text="Tag").grid(row=0, column=0, sticky="e")
+        self.var_tag = tk.StringVar(value="all")
+        self.box_tag = ttk.Combobox(f, textvariable=self.var_tag, values=["all"])
+        self.box_tag.grid(row=0, column=1, padx=4, pady=2)
+
+        ttk.Label(f, text="Sort").grid(row=1, column=0, sticky="e")
+        self.var_sort = tk.StringVar(value="popular")
+        ttk.Combobox(f, textvariable=self.var_sort, values=["latest", "popular"]).grid(row=1, column=1, padx=4, pady=2)
+
+        ttk.Button(f, text="Apply", command=self._apply_filter).grid(row=2, column=0, columnspan=2, pady=4)
+
+    # World list tab
+    def _build_list_tab(self) -> None:
+        self.listbox = tk.Listbox(self.tab_list)
+        self.listbox.pack(fill=tk.BOTH, expand=True)
+
+    # User worlds tab
+    def _build_user_tab(self) -> None:
+        self.text_user = tk.Text(self.tab_user, wrap="word")
+        self.text_user.pack(fill=tk.BOTH, expand=True)
+
+    # ------------------------------------------------------------------
+    # Actions
+    def _load_auth_headers(self) -> None:
+        cookie = self.var_cookie.get() or None
+        user = self.var_user.get() or None
+        pw = self.var_pass.get() or None
+        self.headers = _load_headers(cookie, user, pw)
+
+    def _on_search(self) -> None:
+        self._load_auth_headers()
+        keyword = self.var_keyword.get().strip()
+        if not keyword:
+            messagebox.showerror("Error", "Keyword required")
             return
-        w = self.worlds[self.index]
-        self.label_name.config(text=f"{w.get('name')} by {w.get('author')}")
-        desc = (
-            f"ID: {w.get('worldId')}\n"
-            f"Visits: {w.get('visits', 0)}\n"
-            f"Tags: {', '.join(w.get('tags', []))}\n\n"
-            f"{w.get('description', '')}"
-        )
-        self.text_desc.delete('1.0', tk.END)
-        self.text_desc.insert(tk.END, desc)
-        status = self.reviews.get(w['worldId'], 'pending')
-        self.status_label.config(text=status)
+        try:
+            self.data = fetch_worlds(keyword=keyword, limit=50, headers=self.headers)
+            with open(RAW_FILE, "w", encoding="utf-8") as f:
+                json.dump(self.data, f, ensure_ascii=False, indent=2)
+            self.text_data.delete("1.0", tk.END)
+            self.text_data.insert(tk.END, json.dumps(self.data, ensure_ascii=False, indent=2))
+            self._update_tag_options()
+            self.nb.select(self.tab_data)
+        except Exception as e:  # pragma: no cover - runtime only
+            messagebox.showerror("Error", str(e))
 
-    def _save(self):
-        with open(REVIEW_FILE, 'w', encoding='utf-8') as f:
-            json.dump(self.reviews, f, ensure_ascii=False, indent=2)
+    def _on_user(self) -> None:
+        self._load_auth_headers()
+        user_id = self.var_userid.get().strip()
+        if not user_id:
+            messagebox.showerror("Error", "User ID required")
+            return
+        try:
+            self.user_data = fetch_worlds(user_id=user_id, limit=50, headers=self.headers)
+            with open(USER_FILE, "w", encoding="utf-8") as f:
+                json.dump(self.user_data, f, ensure_ascii=False, indent=2)
+            self.text_user.delete("1.0", tk.END)
+            self.text_user.insert(tk.END, json.dumps(self.user_data, ensure_ascii=False, indent=2))
+            self.nb.select(self.tab_user)
+        except Exception as e:  # pragma: no cover - runtime only
+            messagebox.showerror("Error", str(e))
 
-    def _approve(self):
-        if self.index < len(self.worlds):
-            w = self.worlds[self.index]
-            self.reviews[w['worldId']] = 'approved'
-            self._save()
-            self.index += 1
-            self._show_world()
+    def _update_tag_options(self) -> None:
+        tags = set()
+        for w in self.data:
+            for t in w.get("tags", []):
+                tags.add(t)
+        self.box_tag["values"] = ["all"] + sorted(tags)
+        self.var_tag.set("all")
 
-    def _reject(self):
-        if self.index < len(self.worlds):
-            w = self.worlds[self.index]
-            self.reviews[w['worldId']] = 'rejected'
-            self._save()
-            self.index += 1
-            self._show_world()
+    def _apply_filter(self) -> None:
+        worlds = list(self.data)
+        tag = self.var_tag.get()
+        if tag != "all":
+            worlds = [w for w in worlds if tag in w.get("tags", [])]
+        if self.var_sort.get() == "latest":
+            worlds.sort(key=lambda w: w.get("publicationDate", ""), reverse=True)
+        else:
+            worlds.sort(key=lambda w: w.get("visits", 0), reverse=True)
+        self.filtered = worlds
+        self.listbox.delete(0, tk.END)
+        for w in self.filtered:
+            name = w.get("name") or w.get("世界名稱")
+            visits = w.get("visits") or w.get("瀏覽人次")
+            self.listbox.insert(tk.END, f"{name} ({visits})")
+        self.nb.select(self.tab_list)
 
-    def _next(self):
-        self.index += 1
-        self._show_world()
 
-
-def main() -> None:
-    app = ReviewUI()
+def main() -> None:  # pragma: no cover - simple runtime entry
+    app = WorldInfoUI()
     app.mainloop()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- replace old review UI with a tab-based interface
- allow entering cookie or basic-auth info along with search keyword and user ID
- support fetching keyword search results and user worlds
- add filtering tab to sort by tag and show a world list

## Testing
- `python -m py_compile world_info/scraper/scraper.py world_info/ui.py`
- `pip install requests` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6886da21df6c832da5455e0368c9dcb0