### PR TITLE
Fix VRChat world info scraper syntax errors

### DIFF
--- a/world_info/scraper/scraper.py
+++ b/world_info/scraper/scraper.py
@@ -41,7 +41,6 @@ HISTORY_FILE = BASE / "history.json"
 HISTORY_TABLE = BASE / "history_table.xlsx"
 EXCEL_FILE = BASE / "worlds.xlsx"
 
-    headers = {"User-Agent": "Mozilla/5.0"}
 
 def _load_headers(cookie: Optional[str] = None,
                   username: Optional[str] = None,
@@ -249,86 +248,6 @@ def _append_excel_row(row: List[object]) -> None:
         ws.append(headers)
     ws.append(row)
     wb.save(EXCEL_FILE)
-
-def _append_history_table(row: List[object]) -> None:
-    """Append a metrics row to ``history_table.xlsx``."""
-    headers = [
-        "爬取日期",
-        "世界名稱",
-        "世界ID",
-        "發布日期",
-        "最後更新",
-        "瀏覽人次",
-        "大小",
-        "收藏次數",
-        "熱度",
-        "人氣",
-        "實驗室到發布",
-        "瀏覽蒐藏比",
-        "距離上次更新",
-        "已發布",
-        "人次發布比",
-    ]
-    if Workbook is None or load_workbook is None:
-        raise RuntimeError("openpyxl is required to write Excel logs")
-    if HISTORY_TABLE.exists():
-        wb = load_workbook(HISTORY_TABLE)
-        ws = wb.active
-    else:
-        wb = Workbook()
-        ws = wb.active
-        ws.append(headers)
-    ws.append(row)
-    wb.save(HISTORY_TABLE)
-
-
-def _append_excel_row(row: List[object]) -> None:
-    """Append a metrics row to ``worlds.xlsx``."""
-    headers = [
-        "爬取日期",
-        "世界名稱",
-        "世界ID",
-        "發布日期",
-        "最後更新",
-        "瀏覽人次",
-        "大小",
-        "收藏次數",
-        "熱度",
-        "人氣",
-        "實驗室到發布",
-        "瀏覽蒐藏比",
-        "距離上次更新",
-        "已發布",
-        "人次發布比",
-    ]
-    if Workbook is None or load_workbook is None:
-        raise RuntimeError("openpyxl is required to write Excel logs")
-    if EXCEL_FILE.exists():
-        wb = load_workbook(EXCEL_FILE)
-        ws = wb.active
-    else:
-        wb = Workbook()
-        ws = wb.active
-        ws.append(headers)
-    ws.append(row)
-    wb.save(EXCEL_FILE)
-
-    return [
-        world.get("name"),
-        world.get("id"),
-        world.get("publicationDate"),
-        world.get("updated_at"),
-        visits,
-        world.get("capacity"),
-        favs,
-        world.get("heat"),
-        world.get("popularity"),
-        days_labs_to_pub,
-        ratio_vf,
-        since_update,
-        world.get("releaseStatus"),
-        visits_per_day,
-    ]
 
 def _fetch_paginated(base_url: str, limit: int, delay: float,
                      headers: Optional[Dict[str, str]] = None) -> List[dict]:


### PR DESCRIPTION
## Summary
- remove stray indentation and duplicate functions in world_info scraper
- allow Tkinter UI to launch without immediate crash

## Testing
- `python -m py_compile world_info/scraper/scraper.py`
- `python world_info/ui.py` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_688ffd319a20832dbe1ca17fa112b104