### PR TITLE
Track daily world statistics

### DIFF
--- a/world_info/analytics.py
+++ b/world_info/analytics.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+from typing import List
+
+try:
+    from openpyxl import Workbook, load_workbook  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    Workbook = None  # type: ignore
+    load_workbook = None  # type: ignore
+
+from scraper.scraper import _parse_date
+
+BASE = Path(__file__).resolve().parent
+ANALYTICS_DIR = BASE.parent / "analytics"
+
+COLUMNS = ["date", "total_worlds", "new_worlds_today"]
+
+def update_daily_stats(source_name: str, worlds: List[dict]) -> None:
+    """Update daily world statistics for the given ``source_name``."""
+    if Workbook is None or load_workbook is None:
+        return
+
+    ANALYTICS_DIR.mkdir(exist_ok=True)
+    file_path = ANALYTICS_DIR / f"daily_stats_{source_name}.xlsx"
+
+    stats = _calculate_stats(worlds)
+    wb, ws = _load_or_create_workbook(file_path)
+    _write_row(ws, stats)
+    wb.save(file_path)
+
+def _calculate_stats(worlds: List[dict]) -> dict:
+    today = dt.datetime.now(dt.timezone.utc)
+    today_str = today.strftime("%Y/%m/%d")
+    today_date = today.date()
+    new_today = 0
+    for w in worlds:
+        pub = _parse_date(w.get("publicationDate"))
+        if pub and pub.date() == today_date:
+            new_today += 1
+    return {
+        "date": today_str,
+        "total_worlds": len(worlds),
+        "new_worlds_today": new_today,
+    }
+
+def _load_or_create_workbook(file_path: Path):
+    if file_path.exists():
+        wb = load_workbook(file_path)
+        ws = wb.active
+        header = [cell.value for cell in ws[1]]
+        if header != COLUMNS:
+            rows = list(ws.iter_rows(min_row=2, values_only=True))
+            wb = Workbook()
+            ws = wb.active
+            ws.append(COLUMNS)
+            for row in rows:
+                row = list(row)
+                row += [""] * (len(COLUMNS) - len(row))
+                ws.append(row)
+    else:
+        wb = Workbook()
+        ws = wb.active
+        ws.append(COLUMNS)
+    return wb, ws
+
+def _write_row(ws, stats: dict) -> None:
+    date_str = stats["date"]
+    row_idx = None
+    for idx in range(2, ws.max_row + 1):
+        if ws.cell(row=idx, column=1).value == date_str:
+            row_idx = idx
+            break
+    if row_idx is None:
+        row_idx = ws.max_row + 1
+    for col, key in enumerate(COLUMNS, start=1):
+        ws.cell(row=row_idx, column=col, value=stats.get(key, ""))

--- a/world_info/ui.py
+++ b/world_info/ui.py
@@ -38,6 +38,8 @@ except Exception:  # pragma: no cover - optional
     load_workbook = None  # type: ignore
     Workbook = None  # type: ignore
 
+from analytics import update_daily_stats
+
 BASE = Path(__file__).resolve().parent
 RAW_FILE = BASE / "scraper" / "raw_worlds.json"
 USER_FILE = BASE / "scraper" / "user_worlds.json"
@@ -410,7 +412,7 @@ class WorldInfoUI(tk.Tk):
             ws.append(record_row(w))
         wb.save(file)
 
-    def _search_fixed(self, keywords: str, out_file: Path) -> None:
+    def _search_fixed(self, keywords: str, out_file: Path, source_name: str | None = None) -> None:
         kw_list = [k.strip() for k in keywords.split(",") if k.strip()]
         blacklist = {k.strip() for k in self.settings.get("blacklist", "").split(",") if k.strip()}
         all_worlds: list[dict] = []
@@ -429,14 +431,24 @@ class WorldInfoUI(tk.Tk):
         self.history = load_history()
         self._update_history_options()
         self._save_worlds(all_worlds, out_file)
+        if source_name:
+            update_daily_stats(source_name, all_worlds)
 
     def _search_personal(self) -> None:
         self._load_auth_headers()
-        self._search_fixed(self.settings.get("personal_keywords", ""), PERSONAL_FILE)
+        self._search_fixed(
+            self.settings.get("personal_keywords", ""),
+            PERSONAL_FILE,
+            "starriver",
+        )
 
     def _search_taiwan(self) -> None:
         self._load_auth_headers()
-        self._search_fixed(self.settings.get("taiwan_keywords", ""), TAIWAN_FILE)
+        self._search_fixed(
+            self.settings.get("taiwan_keywords", ""),
+            TAIWAN_FILE,
+            "taiwan",
+        )
     # ------------------------------------------------------------------
     # Actions
     def _load_auth_headers(self) -> None:


### PR DESCRIPTION
## Summary
- add `analytics.update_daily_stats` to compute daily world metrics and keep source files in sync
- update UI searches to write daily stats for Taiwan and StarRiver sources

## Testing
- `python -m py_compile world_info/analytics.py world_info/ui.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689058fe0da0832d8adccba13dbb959a