### PR TITLE
Add configurable search modes

### DIFF
--- a/world_info/analytics.py
+++ b/world_info/analytics.py
@@ -17,13 +17,32 @@ ANALYTICS_DIR = BASE.parent / "analytics"
 
 COLUMNS = ["date", "total_worlds", "new_worlds_today"]
 
-def update_daily_stats(source_name: str, worlds: List[dict]) -> None:
-    """Update daily world statistics for the given ``source_name``."""
+def update_daily_stats(source_name: str, worlds: List[dict],
+                       file_path: Path | str | None = None) -> None:
+    """Update daily world statistics for ``source_name``.
+
+    Parameters
+    ----------
+    source_name:
+        Identifier for the world source, used when ``file_path`` is not
+        provided.
+    worlds:
+        List of world dictionaries to summarise.
+    file_path:
+        Optional path to the stats workbook.  If omitted, the file will be
+        created inside ``ANALYTICS_DIR`` using ``source_name``.
+    """
     if Workbook is None or load_workbook is None:
         return
 
     ANALYTICS_DIR.mkdir(exist_ok=True)
-    file_path = ANALYTICS_DIR / f"daily_stats_{source_name}.xlsx"
+    if file_path is None:
+        file_path = ANALYTICS_DIR / f"daily_stats_{source_name}.xlsx"
+    else:
+        file_path = Path(file_path)
+        if not file_path.is_absolute():
+            file_path = ANALYTICS_DIR / file_path
+        file_path.parent.mkdir(parents=True, exist_ok=True)
 
     stats = _calculate_stats(worlds)
     wb, ws = _load_or_create_workbook(file_path)

--- a/world_info/config/search_modes.json
+++ b/world_info/config/search_modes.json
@@ -1,0 +1,4 @@
+{
+  "taiwan": {"type": "keyword", "keywords": ["台灣", "Taiwan"], "stats": "analytics/daily_stats_taiwan.xlsx"},
+  "starriver": {"type": "user", "user_id": "StarRiverArts", "stats": "analytics/daily_stats_starriver.xlsx"}
+}

--- a/world_info/mode_crawler.py
+++ b/world_info/mode_crawler.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Dict
+
+from analytics import update_daily_stats
+from scraper.scraper import (
+    search_worlds,
+    get_user_worlds,
+    update_history,
+    record_row,
+)
+
+try:
+    from openpyxl import Workbook, load_workbook  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    Workbook = None  # type: ignore
+    load_workbook = None  # type: ignore
+
+BASE = Path(__file__).resolve().parent
+CONFIG_FILE = BASE / "config" / "search_modes.json"
+ANALYTICS_DIR = BASE.parent / "analytics"
+
+# Columns used when saving results to Excel
+METRIC_COLS = [
+    "世界名稱",
+    "世界ID",
+    "發布日期",
+    "最後更新",
+    "瀏覽人次",
+    "大小",
+    "收藏次數",
+    "熱度",
+    "人氣",
+    "實驗室到發布",
+    "瀏覽蒐藏比",
+    "距離上次更新",
+    "已發布",
+    "人次發布比",
+]
+
+
+def _save_worlds(worlds: List[dict], file_path: Path) -> None:
+    """Append ``worlds`` to the Excel sheet at ``file_path``."""
+    if Workbook is None or load_workbook is None:
+        return
+    if file_path.exists():
+        wb = load_workbook(file_path)
+        ws = wb.active
+    else:
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        wb = Workbook()
+        ws = wb.active
+        ws.append(METRIC_COLS)
+    for w in worlds:
+        ws.append(record_row(w))
+    wb.save(file_path)
+
+
+def _run_mode(name: str, cfg: Dict[str, object]) -> None:
+    mode_type = cfg.get("type")
+    worlds: List[dict] = []
+    if mode_type == "keyword":
+        for kw in cfg.get("keywords", []):
+            worlds.extend(search_worlds(str(kw), limit=50))
+    elif mode_type == "user":
+        user_id = str(cfg.get("user_id", ""))
+        if user_id:
+            worlds = get_user_worlds(user_id, limit=50)
+    else:
+        return
+    if not worlds:
+        return
+    update_history(worlds)
+    sheet_file = ANALYTICS_DIR / f"{name}WorldSheet.xlsx"
+    _save_worlds(worlds, sheet_file)
+    stats_path = cfg.get("stats")
+    if stats_path:
+        stats_path = Path(str(stats_path))
+        if not stats_path.is_absolute():
+            stats_path = BASE.parent / stats_path
+    update_daily_stats(name, worlds, stats_path)
+
+
+def main() -> None:
+    if not CONFIG_FILE.exists():
+        raise SystemExit(f"Config file not found: {CONFIG_FILE}")
+    with open(CONFIG_FILE, "r", encoding="utf-8") as f:
+        modes = json.load(f)
+    for name, cfg in modes.items():
+        if isinstance(cfg, dict):
+            _run_mode(name, cfg)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- allow `update_daily_stats` to accept a custom output path
- add JSON `search_modes` config and mode crawler to drive world searches
- save results per mode to Excel and update daily stats automatically

## Testing
- `python -m py_compile world_info/analytics.py world_info/mode_crawler.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68905b45e700832da5a5878b49422f02