### PR TITLE
Handle empty world data in review UI

### DIFF
--- a/track_results/ui.py
+++ b/track_results/ui.py
@@ -22,8 +22,8 @@ class WorldReviewTab(ttk.Frame):
     def __init__(self, master: ttk.Frame) -> None:
         super().__init__(master)
         self.pack(fill=tk.BOTH, expand=True)
-        self.worlds = self._load_json(RAW_FILE)
-        self.reviews = self._load_json(REVIEW_FILE, default={})
+        self.worlds = self._load_json(RAW_FILE) or []
+        self.reviews = self._load_json(REVIEW_FILE) or {}
         self.index = 0
         self._build_widgets()
         self._show_world()
@@ -52,6 +52,11 @@ class WorldReviewTab(ttk.Frame):
             json.dump(self.reviews, f, ensure_ascii=False, indent=2)
 
     def _show_world(self):
+        if not self.worlds:
+            self.label_name.config(text="無資料")
+            self.text_desc.delete("1.0", tk.END)
+            self.status_label.config(text="")
+            return
         if self.index >= len(self.worlds):
             self.label_name.config(text="")
             self.text_desc.delete("1.0", tk.END)


### PR DESCRIPTION
## Summary
- Default world and review data to empty collections when JSON files are absent
- Show "無資料" and exit early in review tab when no worlds are available

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890631359f8832d8c677becca69bfca