### PR TITLE
Fix personal search and reload of local world table

### DIFF
--- a/world_info/ui.py
+++ b/world_info/ui.py
@@ -209,13 +209,19 @@ class WorldInfoUI(tk.Tk):
         self.tab_user_list = ttk.Frame(self.detail_nb)
         self.detail_nb.add(self.tab_user_list, text="所有世界")
 
-        self.user_tree = ttk.Treeview(self.tab_user_list, show="headings")
+        control = ttk.Frame(self.tab_user_list)
+        control.pack(fill=tk.X)
+        ttk.Button(control, text="Reload", command=self._load_local_tables).pack(side="left")
+
+        tree_frame = ttk.Frame(self.tab_user_list)
+        tree_frame.pack(fill=tk.BOTH, expand=True)
+        self.user_tree = ttk.Treeview(tree_frame, show="headings")
         columns = ["爬取日期"] + METRIC_COLS
         self.user_tree["columns"] = list(range(len(columns)))
         for idx, col in enumerate(columns):
             self.user_tree.heading(str(idx), text=col)
             self.user_tree.column(str(idx), width=80, anchor="center")
-        vsb = ttk.Scrollbar(self.tab_user_list, orient="vertical", command=self.user_tree.yview)
+        vsb = ttk.Scrollbar(tree_frame, orient="vertical", command=self.user_tree.yview)
         self.user_tree.configure(yscrollcommand=vsb.set)
         self.user_tree.pack(side="left", fill=tk.BOTH, expand=True)
         vsb.pack(side="right", fill=tk.Y)
@@ -315,6 +321,12 @@ class WorldInfoUI(tk.Tk):
         """Load existing personal Excel file and populate the user world list."""
         if load_workbook is None:
             return
+
+        # clear previous content so the method can be reused for reloading
+        for item in self.user_tree.get_children():
+            self.user_tree.delete(item)
+        self.user_data.clear()
+
         file_name = self.settings.get("personal_file", PERSONAL_FILE.name)
         file_path = BASE / "scraper" / file_name
         if file_path.exists():
@@ -435,12 +447,31 @@ class WorldInfoUI(tk.Tk):
             update_daily_stats(source_name, all_worlds)
 
     def _search_personal(self) -> None:
+        """Fetch worlds for the configured player ID and refresh the table."""
         self._load_auth_headers()
-        self._search_fixed(
-            self.settings.get("personal_keywords", ""),
-            PERSONAL_FILE,
-            "starriver",
-        )
+        user_id = self.settings.get("player_id", "").strip()
+        if not user_id:
+            messagebox.showerror("Error", "Player ID required")
+            return
+        try:
+            worlds = fetch_worlds(user_id=user_id, limit=50, headers=self.headers)
+        except Exception as e:  # pragma: no cover - runtime only
+            messagebox.showerror("Error", str(e))
+            return
+
+        fetch_date = dt.datetime.now(dt.timezone.utc).strftime("%Y/%m/%d")
+        for w in worlds:
+            w["爬取日期"] = fetch_date
+
+        self._save_worlds(worlds, PERSONAL_FILE)
+        update_history(worlds)
+        self.history = load_history()
+        self._update_history_options()
+        update_daily_stats("starriver", worlds)
+
+        # reload the table so manual edits remain and new data is visible
+        self._load_local_tables()
+        self.nb.select(self.tab_user)
 
     def _search_taiwan(self) -> None:
         self._load_auth_headers()


### PR DESCRIPTION
## Summary
- Reload personal world list from Excel to pick up manual edits
- Search personal worlds by stored player ID and update stats
- Add UI control to manually reload the personal table

## Testing
- `python -m py_compile world_info/ui.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68901b6699c4832db4446273c8ea0bef