### PR TITLE
Handle empty world data and extra table columns

### DIFF
--- a/track_results/ui.py
+++ b/track_results/ui.py
@@ -9,6 +9,7 @@ from tkinter import ttk, filedialog, messagebox
 
 
 from pathlib import Path
+import traceback
 
 
 WORLD_BASE = Path(__file__).resolve().parent.parent / "world_info"
@@ -22,8 +23,8 @@ class WorldReviewTab(ttk.Frame):
     def __init__(self, master: ttk.Frame) -> None:
         super().__init__(master)
         self.pack(fill=tk.BOTH, expand=True)
-        self.worlds = self._load_json(RAW_FILE)
-        self.reviews = self._load_json(REVIEW_FILE, default={})
+        self.worlds = self._load_json(RAW_FILE, [])
+        self.reviews = self._load_json(REVIEW_FILE, {})
         self.index = 0
         self._build_widgets()
         self._show_world()
@@ -52,6 +53,11 @@ class WorldReviewTab(ttk.Frame):
             json.dump(self.reviews, f, ensure_ascii=False, indent=2)
 
     def _show_world(self):
+        if not self.worlds:
+            self.label_name.config(text="無資料")
+            self.text_desc.delete("1.0", tk.END)
+            self.status_label.config(text="")
+            return
         if self.index >= len(self.worlds):
             self.label_name.config(text="")
             self.text_desc.delete("1.0", tk.END)
@@ -194,5 +200,9 @@ class RacingUI(tk.Tk):
 
 
 if __name__ == "__main__":
-    app = RacingUI()
-    app.mainloop()
+    try:
+        app = RacingUI()
+        app.mainloop()
+    except Exception:
+        traceback.print_exc()
+        input("Press Enter to exit...")

--- a/world_info/ui.py
+++ b/world_info/ui.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import json
 import datetime as dt
 from pathlib import Path
+import traceback
 import tkinter as tk
 from tkinter import ttk, messagebox
 
@@ -321,44 +322,32 @@ class WorldInfoUI(tk.Tk):
             wb = load_workbook(file_path)
             ws = wb.active
             for row in ws.iter_rows(min_row=2, values_only=True):
-                self.user_tree.insert("", tk.END, values=row)
-                if len(row) == 15:
-                    (
-                        fetched,
-                        name,
-                        wid,
-                        pub,
-                        upd,
-                        visits,
-                        size,
-                        fav,
-                        heat,
-                        pop,
-                        labs_to_pub,
-                        vf,
-                        since_upd,
-                        released,
-                        vpp,
-                    ) = row
-                else:
+                if len(row) >= 15:
+                    row = row[:15]
+                elif len(row) >= 14:
                     # backward compatibility with old files without fetch date
-                    fetched = ""
-                    (
-                        name,
-                        wid,
-                        pub,
-                        upd,
-                        visits,
-                        size,
-                        fav,
-                        heat,
-                        pop,
-                        labs_to_pub,
-                        vf,
-                        since_upd,
-                        released,
-                        vpp,
-                    ) = row
+                    row = ("",) + row[:14]
+                else:
+                    # skip rows that don't have enough columns
+                    continue
+                self.user_tree.insert("", tk.END, values=row)
+                (
+                    fetched,
+                    name,
+                    wid,
+                    pub,
+                    upd,
+                    visits,
+                    size,
+                    fav,
+                    heat,
+                    pop,
+                    labs_to_pub,
+                    vf,
+                    since_upd,
+                    released,
+                    vpp,
+                ) = row
                 self.user_data.append(
                     {
                         "爬取日期": fetched,
@@ -378,8 +367,26 @@ class WorldInfoUI(tk.Tk):
                         "人次發布比": vpp,
                     }
                 )
+                ts = _parse_date(fetched)
+                if ts:
+                    rec = {
+                        "timestamp": int(ts.timestamp()),
+                        "name": name,
+                        "visits": visits,
+                        "favorites": fav,
+                        "heat": heat,
+                        "popularity": pop,
+                        "updated_at": upd,
+                        "publicationDate": pub,
+                        "labsPublicationDate": "",
+                    }
+                    recs = self.history.setdefault(wid, [])
+                    if not any(r.get("timestamp") == rec["timestamp"] for r in recs):
+                        recs.append(rec)
+                        recs.sort(key=lambda r: r.get("timestamp", 0))
             self._create_world_tabs()
             self._update_dashboard()
+            self._update_history_options()
 
     def _save_worlds(self, worlds: list[dict], file: Path) -> None:
         if Workbook is None or load_workbook is None:
@@ -433,6 +440,9 @@ class WorldInfoUI(tk.Tk):
         self._save_worlds(all_worlds, out_file)
         if source_name:
             update_daily_stats(source_name, all_worlds)
+        self.data = all_worlds
+        self._update_tag_options()
+        self._apply_filter()
 
     def _search_personal(self) -> None:
         self._load_auth_headers()
@@ -890,10 +900,10 @@ class WorldInfoUI(tk.Tk):
 def main() -> None:  # pragma: no cover - simple runtime entry
     try:
         app = WorldInfoUI()
-    except tk.TclError as e:  # pragma: no cover - runtime only
-        print("Failed to launch Tkinter UI:", e)
-        return
-    app.mainloop()
+        app.mainloop()
+    except Exception:  # pragma: no cover - runtime only
+        traceback.print_exc()
+        input("Press Enter to exit...")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Default world and review data to empty collections when JSON files are absent
- Trim or pad Excel rows before inserting into the user world table to avoid column mismatches
- Wrap UI entrypoints to print errors and pause so the console stays open on failure
- Integrate manually entered world stats into history and draw lists from preset searches

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890631359f8832d8c677becca69bfca