### PR TITLE
Handle empty world data, extra table columns, and responsive charts

### DIFF
--- a/track_results/ui.py
+++ b/track_results/ui.py
@@ -9,6 +9,7 @@ from tkinter import ttk, filedialog, messagebox
 
 
 from pathlib import Path
+import traceback
 
 
 WORLD_BASE = Path(__file__).resolve().parent.parent / "world_info"
@@ -22,8 +23,8 @@ class WorldReviewTab(ttk.Frame):
     def __init__(self, master: ttk.Frame) -> None:
         super().__init__(master)
         self.pack(fill=tk.BOTH, expand=True)
-        self.worlds = self._load_json(RAW_FILE)
-        self.reviews = self._load_json(REVIEW_FILE, default={})
+        self.worlds = self._load_json(RAW_FILE, [])
+        self.reviews = self._load_json(REVIEW_FILE, {})
         self.index = 0
         self._build_widgets()
         self._show_world()
@@ -52,6 +53,11 @@ class WorldReviewTab(ttk.Frame):
             json.dump(self.reviews, f, ensure_ascii=False, indent=2)
 
     def _show_world(self):
+        if not self.worlds:
+            self.label_name.config(text="無資料")
+            self.text_desc.delete("1.0", tk.END)
+            self.status_label.config(text="")
+            return
         if self.index >= len(self.worlds):
             self.label_name.config(text="")
             self.text_desc.delete("1.0", tk.END)
@@ -194,5 +200,9 @@ class RacingUI(tk.Tk):
 
 
 if __name__ == "__main__":
-    app = RacingUI()
-    app.mainloop()
+    try:
+        app = RacingUI()
+        app.mainloop()
+    except Exception:
+        traceback.print_exc()
+        input("Press Enter to exit...")


### PR DESCRIPTION
## Summary
- Default world and review data to empty collections when JSON files are absent
- Trim or pad Excel rows before inserting into the user world table to avoid column mismatches
- Wrap UI entrypoints to print errors and pause so the console stays open on failure
- Integrate manually entered world stats into history and draw lists from preset searches
- Redraw personal world line charts on window resize so dashboard and detail views scale with the UI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890631359f8832d8c677becca69bfca