### PR TITLE
docs: update readme and add about tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,41 @@
-# VRChat WorldInfo by StarRiver
+# VRChat 工具集
 
-This repository contains two separate toolsets:
+VRChat 工具集是一個互動式工具組，包含賽道成績 (Track Results) 與世界資訊 (World Info) 兩部分。它能從 Google 試算表與 VRChat API 取得資料，產生排行榜、歷史紀錄並匯出 JSON 或靜態網站。介面採用 Tkinter，方便在桌面環境操作審核流程。
 
-## Track Results
-Utilities that download racing records from a Google Spreadsheet and
-build text or HTML leaderboards. See [`track_results/README.md`](track_results/README.md)
-for full usage instructions.
+本專案由星河 StarRiver 與 Codex AI 協作開發。
 
-## World Info
-A workflow for collecting VRChat world information and approving entries.
-It exports a JSON file for use on a website or inside Unity and includes a
-simple Tkinter interface for reviewing worlds.
-See [`world_info/README.md`](world_info/README.md) for details.
-Additional background is available in
-[`world_info/complete_guide.zh_TW.md`](world_info/complete_guide.zh_TW.md) (Chinese).
+## 功能簡介
+- **Track Results**：下載賽車紀錄並建立文字或 HTML 排行榜。詳見 [`track_results/README.md`](track_results/README.md)。
+- **World Info**：收集世界資訊、維護歷史資料並提供圖形審核介面。詳見 [`world_info/README.md`](world_info/README.md)。
 
-### Recent updates
-- Line charts on the personal dashboard and per-world tabs resize with the window.
-- Scrollbars keep long reviews, player lists and raw JSON tables accessible.
-- Extra columns in local Excel tables are ignored and missing JSON files now default to empty data.
-- UI entry points show a traceback and wait for input instead of closing on errors.
+## 資料來源
+- Google 試算表
+- VRChat 官方 API
 
-Install dependencies with::
+## CREDIT
+星河 StarRiver、Codex AI
 
-  pip install -r requirements.txt
+## 版本歷史
+1.3.2: 2025-08-06  
+- 同步最新世界與賽道資料
 
-If creator-world scraping is required, run ``playwright install`` after installing the packages.
+1.3.1: 2025-08-05  
+- 更新資料檔  
+- 文件加入近期 UI 改進說明
 
-For Traditional Chinese instructions, read
-[`README.zh_TW.md`](README.zh_TW.md).
+1.3.0: 2025-08-05  
+- 新增長內容捲軸  
+- 儀表板圖表支援視窗大小調整  
+- 啟動錯誤顯示 traceback 以利除錯
+
+## 快速開始
+安裝相依套件：
+```bash
+pip install -r requirements.txt
+```
+若需爬取作者世界資料，請於安裝後執行：
+```bash
+playwright install
+```
+
+更多繁體中文說明請參見 [`README.zh_TW.md`](README.zh_TW.md)。

--- a/README.zh_TW.md
+++ b/README.zh_TW.md
@@ -6,15 +6,23 @@
 用於從 Google 試算表下載賽車紀錄並產生文字或 HTML 形式的排行榜。詳盡使用方式請參考 [`track_results/README.zh_TW.md`](track_results/README.zh_TW.md)。
 
 ## 世界資料（World Info）
-用於收集 VRChat 世界資訊、人工審核並匯出可在網站或 Unity 中使用的 JSON 檔案，並附帶簡易的 Tkinter 圖形審核介面。詳細流程請參考 [`world_info/README.zh_TW.md`](world_info/README.zh_TW.md)。
-更完整的架構與流程說明請見
-[`world_info/complete_guide.zh_TW.md`](world_info/complete_guide.zh_TW.md)。
+用於收集 VRChat 世界資訊、人工審核並匯出可在網站或 Unity 中使用的 JSON 檔案，並附帶簡易的 Tkinter 圖形審核介面。詳細流程請參考 [`world_info/README.zh_TW.md`](world_info/README.zh_TW.md)。更完整的架構與流程說明請見 [`world_info/complete_guide.zh_TW.md`](world_info/complete_guide.zh_TW.md)。
 
-### 最新更新
-- 個人儀表板與各世界頁籤的折線圖會隨視窗大小縮放。
-- 介面新增捲軸，長篇審核內容、玩家列表與原始 JSON 表格都能完整檢視。
-- 匯入的 Excel 資料會自動忽略多餘欄位，缺少的 JSON 檔則以空資料處理。
-- UI 入口點會顯示錯誤追蹤並暫停，避免視窗立即關閉。
+## CREDIT
+星河 StarRiver、Codex AI
+
+## 版本歷史
+1.3.2: 2025-08-06  
+- 同步最新世界與賽道資料
+
+1.3.1: 2025-08-05  
+- 更新資料檔  
+- 文件加入近期 UI 改進說明
+
+1.3.0: 2025-08-05  
+- 新增長內容捲軸  
+- 儀表板圖表支援視窗大小調整  
+- UI 入口點顯示錯誤追蹤並暫停
 
 安裝相依套件：
 
@@ -78,4 +86,3 @@ world_info/
 
 - 本倉庫的 `track_results` 腳本須能連線到 Google 服務方可正常運作。
 - `world_info` 相關檔案會產生 JSON 於本地端，預設不會提交到版本控制。
-

--- a/world_info/ui.py
+++ b/world_info/ui.py
@@ -99,6 +99,7 @@ class WorldInfoUI(tk.Tk):
         self.tab_user = ttk.Frame(self.nb)
         self.tab_history = ttk.Frame(self.nb)
         self.tab_settings = ttk.Frame(self.nb)
+        self.tab_about = ttk.Frame(self.nb)
 
         self.nb.add(self.tab_entry, text="入口")
         self.nb.add(self.tab_data, text="資料")
@@ -107,6 +108,7 @@ class WorldInfoUI(tk.Tk):
         self.nb.add(self.tab_user, text="個人世界")
         self.nb.add(self.tab_history, text="歷史記錄")
         self.nb.add(self.tab_settings, text="設定")
+        self.nb.add(self.tab_about, text="關於")
 
         self._build_entry_tab()
         self._build_data_tab()
@@ -115,6 +117,7 @@ class WorldInfoUI(tk.Tk):
         self._build_user_tab()
         self._build_history_tab()
         self._build_settings_tab()
+        self._build_about_tab()
         self._load_local_tables()
 
     # ------------------------------------------------------------------
@@ -346,6 +349,20 @@ class WorldInfoUI(tk.Tk):
         player_id = self.settings.get("player_id", "")
         self.var_userid.set(player_id)
         self.var_playerid_set.set(player_id)
+
+    def _build_about_tab(self) -> None:
+        frame = self.tab_about
+        text = tk.Text(frame, wrap="word")
+        vsb = ttk.Scrollbar(frame, orient="vertical", command=text.yview)
+        text.configure(yscrollcommand=vsb.set)
+        text.pack(side="left", fill=tk.BOTH, expand=True)
+        vsb.pack(side="right", fill=tk.Y)
+        try:
+            readme = Path(__file__).resolve().parent.parent / "README.md"
+            text.insert("1.0", readme.read_text(encoding="utf-8"))
+        except Exception as e:
+            text.insert("1.0", f"無法讀取 README: {e}")
+        text.configure(state=tk.DISABLED)
 
     def _load_local_tables(self) -> None:
         """Load existing personal Excel file and populate the user world list."""


### PR DESCRIPTION
## Summary
- document project features, credits for StarRiver and Codex AI, and version history in both English and Chinese READMEs
- add "About" tab to world info UI that loads README.md content

## Testing
- `python -m py_compile world_info/ui.py`
- `python -m py_compile track_results/ui.py`


------
https://chatgpt.com/codex/tasks/task_e_6893f16c6cc4832daf80de1c5284896b