### PR TITLE
Add retries and logging to world crawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ VRChat 工具集是一個互動式工具組，包含賽道成績 (Track Results)
 
 ## 功能簡介
 - **Track Results**：下載賽車紀錄並建立文字或 HTML 排行榜。詳見 [`track_results/README.md`](track_results/README.md)。
-- **World Info**：收集世界資訊、維護歷史資料並提供圖形審核介面。詳見 [`world_info/README.md`](world_info/README.md)。
+- **World Info**：收集世界資訊、維護歷史資料並提供圖形審核介面；執行爬蟲時會顯示各模式進度並於結束後輸出抓取的世界總數。詳見 [`world_info/README.md`](world_info/README.md)。
 
 ## 資料來源
 - Google 試算表


### PR DESCRIPTION
## Summary
- add logging and three-attempt retries for fetching worlds
- print total number of worlds fetched after running
- document progress output in README

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68955b98a394832da8744299ed0568c2