### PR TITLE
Add CSV export option and sort leaderboards

### DIFF
--- a/tests/test_build_leaderboards.py
+++ b/tests/test_build_leaderboards.py
@@ -1,0 +1,41 @@
+import csv
+import sys
+from pathlib import Path
+
+
+# Allow importing the script as a module
+sys.path.append(str(Path(__file__).resolve().parent.parent / "track_results"))
+import build_leaderboards as bl  # noqa: E402
+
+
+def sample_rows():
+    """Return sample rows with header for leaderboard generation."""
+    return [
+        ["賽道", "車手", "車輛", "時間", "錦標賽"],
+        ["TrackA", "DriverB", "Car1", "1.5", ""],
+        ["TrackA", "DriverA", "Car1", "1.0", ""],
+        ["TrackB", "DriverC", "Car2", "2.0", "yes"],
+        ["TrackB", "DriverD", "Car2", "1.8", ""],
+    ]
+
+
+def test_parse_leaderboards_sort_and_csv(tmp_path, monkeypatch):
+    monkeypatch.setattr(bl, "DATA_DIR", tmp_path.as_posix())
+
+    rows = sample_rows()
+    lines = bl.parse_leaderboards(rows, output_csv=True)
+
+    start = lines.index("Driver career best:") + 1
+    end = lines.index("", start)
+    times = [float(line.split(": ")[1]) for line in lines[start:end]]
+    assert times == sorted(times)
+
+    driver_best_csv = tmp_path / "driver_best.csv"
+    assert driver_best_csv.exists()
+    with driver_best_csv.open(encoding="utf-8") as fh:
+        reader = list(csv.reader(fh))
+    csv_times = [float(r[1]) for r in reader[1:]]
+    assert csv_times == sorted(csv_times)
+
+    championship_csv = tmp_path / "championship_entries.csv"
+    assert championship_csv.exists()

--- a/track_results/README.md
+++ b/track_results/README.md
@@ -40,8 +40,11 @@ marked as belonging to a championship, it will be listed separately.
 Run it with:
 
 ```bash
-python3 build_leaderboards.py
+python3 build_leaderboards.py [--output-csv]
 ```
+
+Use `--output-csv` to additionally write each leaderboard as a CSV file under
+`data/`.
 
 ## prefab/TextDisplay.cs
 

--- a/track_results/README.zh_TW.md
+++ b/track_results/README.zh_TW.md
@@ -27,8 +27,10 @@ python3 generate_summary.py
 `build_leaderboards.py` 整合下載與分析流程，先將原始 CSV 存到 `data/history.csv`，再於 `data/leaderboard.txt` 產生排行榜。內容包含每條賽道最快車手、各車種最佳紀錄、車手生涯最佳等，若標記為錦標賽則另行列出。
 
 ```bash
-python3 build_leaderboards.py
+python3 build_leaderboards.py [--output-csv]
 ```
+
+加上 `--output-csv` 參數會在 `data/` 目錄下輸出對應的 CSV 檔。
 
 ## prefab/TextDisplay.cs
 


### PR DESCRIPTION
## Summary
- sort leaderboard entries and allow optional CSV export via `output_csv`
- expose `--output-csv` CLI flag
- document new flag in English and Chinese READMEs
- add regression tests for CSV output and sorting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68956bba384c832dbd89f830ff56a191