### PR TITLE
feat: extend summary with driver bests and sorted tracks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ VRChat 工具集是一個互動式工具組，包含賽道成績 (Track Results)
 本專案由星河 StarRiver 與 Codex AI 協作開發。
 
 ## 功能簡介
-- **Track Results**：下載賽車紀錄並建立文字或 HTML 排行榜。詳見 [`track_results/README.md`](track_results/README.md)。
+- **Track Results**：下載賽車紀錄並建立文字或 HTML 排行榜，並可產生包含總筆數、各賽道最快與車手最佳時間的統計摘要。詳見 [`track_results/README.md`](track_results/README.md)。
 - **World Info**：收集世界資訊、維護歷史資料並提供圖形審核介面；執行爬蟲時會顯示各模式進度並於結束後輸出抓取的世界總數。詳見 [`world_info/README.md`](world_info/README.md)。
 
 ## 資料來源

--- a/README.zh_TW.md
+++ b/README.zh_TW.md
@@ -3,7 +3,7 @@
 本專案包含兩個獨立的工具集：
 
 ## 賽道成績（Track Results）
-用於從 Google 試算表下載賽車紀錄並產生文字或 HTML 形式的排行榜。詳盡使用方式請參考 [`track_results/README.zh_TW.md`](track_results/README.zh_TW.md)。
+用於從 Google 試算表下載賽車紀錄並產生文字或 HTML 形式的排行榜，也可輸出包含總筆數、各賽道最快與車手最佳時間的統計摘要。詳盡使用方式請參考 [`track_results/README.zh_TW.md`](track_results/README.zh_TW.md)。
 
 ## 世界資料（World Info）
 用於收集 VRChat 世界資訊、人工審核並匯出可在網站或 Unity 中使用的 JSON 檔案，並附帶簡易的 Tkinter 圖形審核介面。詳細流程請參考 [`world_info/README.zh_TW.md`](world_info/README.zh_TW.md)。更完整的架構與流程說明請見 [`world_info/complete_guide.zh_TW.md`](world_info/complete_guide.zh_TW.md)。
@@ -53,7 +53,7 @@ VRChat WorldInfo by StarRiver/
 ```
 track_results/
 ├─ fetch_sheet.py       # 下載試算表中的「歷史紀錄」工作表
-├─ generate_summary.py  # 產生統計摘要報告
+├─ generate_summary.py  # 產生統計摘要報告，列出賽道與車手最佳成績
 ├─ build_leaderboards.py# 建立綜合排行榜文字檔
 ├─ build_site.py        # 產生可放到 GitHub Pages 的網站
 ├─ prefab/TextDisplay.cs# Unity 組件，用來載入並顯示文字檔

--- a/tests/test_generate_summary.py
+++ b/tests/test_generate_summary.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent / "track_results"))
+from generate_summary import summarise  # noqa: E402
+
+
+def test_summarise_includes_sorted_track_and_driver_best():
+    rows = [
+        ["賽道", "車手", "車輛", "時間", "錦標賽"],
+        ["A", "Driver1", "Car1", "10.5", ""],
+        ["A", "Driver2", "Car2", "9.8", ""],
+        ["B", "Driver1", "Car3", "8.0", ""],
+    ]
+    summary = summarise(rows)
+
+    assert summary[0] == "Total entries: 3"
+
+    track_idx = summary.index("Fastest per track (sorted):")
+    track_lines = summary[track_idx + 1 : track_idx + 3]
+    assert track_lines == ["B: 8.0", "A: 9.8"]
+
+    driver_idx = summary.index("Best time per driver:")
+    driver_lines = summary[driver_idx + 1 : driver_idx + 3]
+    assert "Driver1: 8.0" in driver_lines
+    assert "Driver2: 9.8" in driver_lines
+

--- a/track_results/README.md
+++ b/track_results/README.md
@@ -20,7 +20,8 @@ If the environment blocks outbound network requests the script will fail with a
 ## generate_summary.py
 
 `generate_summary.py` builds a small text report from the spreadsheet data.
-The file `report/summary.txt` will be created containing a list of statistics.
+The generated `report/summary.txt` lists the total entry count, fastest time per
+track sorted by time and each driver's best lap.
 
 ```bash
 python3 generate_summary.py

--- a/track_results/README.zh_TW.md
+++ b/track_results/README.zh_TW.md
@@ -14,7 +14,7 @@ python3 fetch_sheet.py
 
 ## generate_summary.py
 
-`generate_summary.py` 會根據試算表建立簡易文字報告，輸出在 `report/summary.txt`。
+`generate_summary.py` 會根據試算表建立簡易文字報告，輸出在 `report/summary.txt`，內容包含總筆數、依時間排序的各賽道最快成績以及每位車手的最佳時間。
 
 ```bash
 python3 generate_summary.py

--- a/track_results/generate_summary.py
+++ b/track_results/generate_summary.py
@@ -17,9 +17,11 @@ def summarise(rows: List[List[str]]) -> List[str]:
     header, *data = rows
     summary = [f"Total entries: {len(data)}"]
 
-    if "賽道" in header and "時間" in header:
-        track_idx = header.index("賽道")
-        time_idx = header.index("時間")
+    track_idx = header.index("賽道") if "賽道" in header else None
+    driver_idx = header.index("車手") if "車手" in header else None
+    time_idx = header.index("時間") if "時間" in header else None
+
+    if track_idx is not None and time_idx is not None:
         best_by_track: dict[str, float] = {}
         for row in data:
             if len(row) <= max(track_idx, time_idx):
@@ -31,9 +33,30 @@ def summarise(rows: List[List[str]]) -> List[str]:
                 continue
             if track not in best_by_track or t < best_by_track[track]:
                 best_by_track[track] = t
-        summary.append("Fastest per track:")
-        for track, t in best_by_track.items():
-            summary.append(f"{track}: {t}")
+        if best_by_track:
+            summary.append("")
+            summary.append("Fastest per track (sorted):")
+            for track, t in sorted(best_by_track.items(), key=lambda item: item[1]):
+                summary.append(f"{track}: {t}")
+
+    if driver_idx is not None and time_idx is not None:
+        best_by_driver: dict[str, float] = {}
+        for row in data:
+            if len(row) <= max(driver_idx, time_idx):
+                continue
+            driver = row[driver_idx]
+            try:
+                t = float(row[time_idx])
+            except ValueError:
+                continue
+            if driver not in best_by_driver or t < best_by_driver[driver]:
+                best_by_driver[driver] = t
+        if best_by_driver:
+            summary.append("")
+            summary.append("Best time per driver:")
+            for driver, t in sorted(best_by_driver.items(), key=lambda item: item[1]):
+                summary.append(f"{driver}: {t}")
+
     return summary
 
 


### PR DESCRIPTION
## Summary
- compute per-track fastest times sorted by lap and per-driver best times
- reorganize summary output into clearly labeled sections
- document new summary details in project READMEs and add tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68956db608d8832d95b1e39035bf2d4d