### PR TITLE
feat: enhance world info dashboards

### DIFF
--- a/world_info/mode_crawler.py
+++ b/world_info/mode_crawler.py
@@ -28,6 +28,7 @@ ANALYTICS_DIR = BASE.parent / "analytics"
 
 # Columns used when saving results to Excel
 METRIC_COLS = [
+    "爬取日期",
     "世界名稱",
     "世界ID",
     "發布日期",

--- a/world_info/scraper/scraper.py
+++ b/world_info/scraper/scraper.py
@@ -90,10 +90,13 @@ def record_row(world: dict, now: Optional[int] = None) -> List[object]:
     days_labs_to_pub = (pub - labs).days if pub and labs else ""
     visits = world.get("visits") or 0
     favs = world.get("favorites") or 0
-    ratio_vf = round(visits / favs, 2) if favs else ""
+    ratio_vf = f"{round(favs / visits * 100, 2)}%" if visits else ""
     since_update = (ts_now - updated).days if updated else ""
     since_pub = (ts_now - pub).days if pub else 0
     visits_per_day = round(visits / since_pub, 2) if since_pub > 0 else ""
+    labs_to_pub_str = f"{days_labs_to_pub}天" if days_labs_to_pub != "" else ""
+    since_update_str = f"{since_update}天" if since_update != "" else ""
+    since_pub_str = f"{since_pub}天" if since_pub else ""
 
     return [
         fetch_date,
@@ -106,10 +109,10 @@ def record_row(world: dict, now: Optional[int] = None) -> List[object]:
         favs,
         world.get("heat"),
         world.get("popularity"),
-        days_labs_to_pub,
+        labs_to_pub_str,
         ratio_vf,
-        since_update,
-        world.get("releaseStatus"),
+        since_update_str,
+        since_pub_str,
         visits_per_day,
     ]
 

--- a/world_info/tabs/user.py
+++ b/world_info/tabs/user.py
@@ -61,15 +61,20 @@ class UserTab:
         f = self.app.tab_dashboard
         tree_frame = ttk.Frame(f)
         tree_frame.pack(fill=tk.X)
+        columns = ["爬取日期"] + METRIC_COLS
         self.app.dash_tree = ttk.Treeview(tree_frame, show="headings")
-        self.app.dash_tree["columns"] = list(range(len(METRIC_COLS)))
-        for idx, col in enumerate(METRIC_COLS):
-            self.app.dash_tree.heading(str(idx), text=col)
+        self.app.dash_tree["columns"] = list(range(len(columns)))
+        for idx, col in enumerate(columns):
+            self.app.dash_tree.heading(
+                str(idx), text=col, command=lambda c=str(idx): self.app._sort_tree(self.app.dash_tree, c)
+            )
             self.app.dash_tree.column(str(idx), width=80, anchor="center")
         self.app.dash_tree.pack(side="left", fill=tk.X, expand=True)
         dash_vsb = ttk.Scrollbar(tree_frame, orient="vertical", command=self.app.dash_tree.yview)
+        dash_hsb = ttk.Scrollbar(tree_frame, orient="horizontal", command=self.app.dash_tree.xview)
+        self.app.dash_tree.configure(yscrollcommand=dash_vsb.set, xscrollcommand=dash_hsb.set)
         dash_vsb.pack(side="right", fill=tk.Y)
-        self.app.dash_tree.configure(yscrollcommand=dash_vsb.set)
+        dash_hsb.pack(side="bottom", fill=tk.X)
 
         self.app.chart_canvas = tk.Canvas(f)
         chart_vsb = ttk.Scrollbar(f, orient="vertical", command=self.app.chart_canvas.yview)

--- a/world_info/tabs/world_list.py
+++ b/world_info/tabs/world_list.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import tkinter as tk
 from tkinter import ttk
 
+from ..constants import METRIC_COLS
+
 
 class ListTab:
     def __init__(self, nb: ttk.Notebook, app) -> None:
@@ -12,15 +14,15 @@ class ListTab:
         self._build()
 
     def _build(self) -> None:
-        columns = ("name", "visits", "id")
-        self.app.tree = ttk.Treeview(self.frame, columns=columns, show="headings")
-        self.app.tree.heading("name", text="Name")
-        self.app.tree.heading("visits", text="Visits")
-        self.app.tree.heading("id", text="World ID")
-        self.app.tree.column("name", width=250)
-        self.app.tree.column("visits", width=80, anchor="e")
-        self.app.tree.column("id", width=200)
+        columns = ["爬取日期"] + METRIC_COLS
+        self.app.tree = ttk.Treeview(self.frame, show="headings")
+        self.app.tree["columns"] = list(range(len(columns)))
+        for idx, col in enumerate(columns):
+            self.app.tree.heading(str(idx), text=col)
+            self.app.tree.column(str(idx), width=80, anchor="center")
         vsb = ttk.Scrollbar(self.frame, orient="vertical", command=self.app.tree.yview)
-        self.app.tree.configure(yscrollcommand=vsb.set)
+        hsb = ttk.Scrollbar(self.frame, orient="horizontal", command=self.app.tree.xview)
+        self.app.tree.configure(yscrollcommand=vsb.set, xscrollcommand=hsb.set)
         self.app.tree.pack(side="left", fill=tk.BOTH, expand=True)
         vsb.pack(side="right", fill=tk.Y)
+        hsb.pack(side="bottom", fill=tk.X)

--- a/world_info/ui.py
+++ b/world_info/ui.py
@@ -38,29 +38,65 @@ except Exception:  # pragma: no cover - optional
     Workbook = None  # type: ignore
 
 from analytics import update_daily_stats
-from .constants import METRIC_COLS, LEGEND_TEXT
-from .tabs import (
-    EntryTab,
-    DataTab,
-    FilterTab,
-    ListTab,
-    UserTab,
-    HistoryTab,
-    SettingsTab,
-    AboutTab,
-)
-from .actions import (
-    BASE,
-    RAW_FILE,
-    USER_FILE,
-    PERSONAL_FILE,
-    TAIWAN_FILE,
-    load_auth_headers,
-    search_keyword,
-    search_user,
-    search_fixed,
-    save_worlds,
-)
+
+# Support running both as a module (``python -m world_info.ui``) and as a
+# stand-alone script.  When executed directly, ``__package__`` is ``None`` and
+# the relative imports below would otherwise fail, causing the console window to
+# close immediately on error.  Instead, adjust ``sys.path`` and import the
+# modules via the package name so that any further relative imports still work.
+if __package__:
+    from .constants import METRIC_COLS, LEGEND_TEXT
+    from .tabs import (
+        EntryTab,
+        DataTab,
+        FilterTab,
+        ListTab,
+        UserTab,
+        HistoryTab,
+        SettingsTab,
+        AboutTab,
+    )
+    from .actions import (
+        BASE,
+        RAW_FILE,
+        USER_FILE,
+        PERSONAL_FILE,
+        TAIWAN_FILE,
+        load_auth_headers,
+        search_keyword,
+        search_user,
+        search_fixed,
+        save_worlds,
+    )
+else:  # pragma: no cover - direct script execution
+    import sys
+    from pathlib import Path
+
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+    from world_info.constants import METRIC_COLS, LEGEND_TEXT
+    from world_info.tabs import (
+        EntryTab,
+        DataTab,
+        FilterTab,
+        ListTab,
+        UserTab,
+        HistoryTab,
+        SettingsTab,
+        AboutTab,
+    )
+    from world_info.actions import (
+        BASE,
+        RAW_FILE,
+        USER_FILE,
+        PERSONAL_FILE,
+        TAIWAN_FILE,
+        load_auth_headers,
+        search_keyword,
+        search_user,
+        search_fixed,
+        save_worlds,
+    )
 
 # configuration and extra spreadsheets
 SETTINGS_FILE = BASE / "scraper" / "settings.json"
@@ -169,7 +205,7 @@ class WorldInfoUI(tk.Tk):
                     labs_to_pub,
                     vf,
                     since_upd,
-                    released,
+                    since_pub,
                     vpp,
                 ) = row
                 self.user_data.append(
@@ -187,7 +223,7 @@ class WorldInfoUI(tk.Tk):
                         "實驗室到發布": labs_to_pub,
                         "瀏覽蒐藏比": vf,
                         "距離上次更新": since_upd,
-                        "已發布": released,
+                        "已發布": since_pub,
                         "人次發布比": vpp,
                     }
                 )
@@ -355,10 +391,8 @@ class WorldInfoUI(tk.Tk):
         for item in self.tree.get_children():
             self.tree.delete(item)
         for w in self.filtered:
-            name = w.get("name") or w.get("世界名稱")
-            visits = w.get("visits") or w.get("瀏覽人次")
-            world_id = w.get("id") or w.get("世界ID")
-            self.tree.insert("", tk.END, values=(name, visits, world_id))
+            row = record_row(w)
+            self.tree.insert("", tk.END, values=row)
         self.nb.select(self.tab_list.frame)
 
     def _update_history_options(self) -> None:
@@ -382,6 +416,11 @@ class WorldInfoUI(tk.Tk):
         data = self.history.get(world_id, [])
         self.canvas.delete("all")
         if not data:
+            self.canvas.create_text(
+                int(self.canvas.winfo_width() or 300) / 2,
+                int(self.canvas.winfo_height() or 150) / 2,
+                text="No history",
+            )
             return
         width = int(self.canvas.winfo_width() or 600)
         height = int(self.canvas.winfo_height() or 300)
@@ -791,7 +830,7 @@ class WorldInfoUI(tk.Tk):
             if wid:
                 unique[wid] = w
         for w in unique.values():
-            row = [w.get(col, "") for col in METRIC_COLS]
+            row = [w.get("爬取日期", "")] + [w.get(col, "") for col in METRIC_COLS]
             self.dash_tree.insert("", tk.END, values=row)
 
         for frame, _, _ in getattr(self, "chart_frames", []):
@@ -815,6 +854,22 @@ class WorldInfoUI(tk.Tk):
             frm.grid(row=idx // cols, column=idx % cols, padx=4, pady=4, sticky="nsew")
         for c in range(cols):
             self.chart_container.columnconfigure(c, weight=1)
+
+    def _sort_tree(self, tree: ttk.Treeview, col: str, reverse: bool = False) -> None:
+        """Sort a ``ttk.Treeview`` by the given column."""
+        data = [(tree.set(k, col), k) for k in tree.get_children("")]
+
+        def convert(val: str):
+            try:
+                val = val.replace("%", "").replace("天", "")
+                return float(val)
+            except Exception:
+                return val
+
+        data.sort(key=lambda t: convert(t[0]), reverse=reverse)
+        for idx, (_val, k) in enumerate(data):
+            tree.move(k, "", idx)
+        tree.heading(col, command=lambda: self._sort_tree(tree, col, not reverse))
 
 
 def main() -> None:  # pragma: no cover - simple runtime entry


### PR DESCRIPTION
## Summary
- compute correct browse-to-favorite percentage and day-based metrics
- add sortable, scrollable tables for personal dashboard and world list
- show message when no history data is available

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895729765b8832d90a2dff6470536de