### PR TITLE
refactor: centralize metric columns

### DIFF
--- a/world_info/mode_crawler.py
+++ b/world_info/mode_crawler.py
@@ -12,6 +12,10 @@ from scraper.scraper import (
     update_history,
     record_row,
 )
+try:
+    from world_info.constants import METRIC_COLS
+except ModuleNotFoundError:  # pragma: no cover - package path
+    from constants import METRIC_COLS
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -25,26 +29,6 @@ except Exception:  # pragma: no cover - optional dependency
 BASE = Path(__file__).resolve().parent
 CONFIG_FILE = BASE / "config" / "search_modes.json"
 ANALYTICS_DIR = BASE.parent / "analytics"
-
-# Columns used when saving results to Excel
-METRIC_COLS = [
-    "爬取日期",
-    "世界名稱",
-    "世界ID",
-    "發布日期",
-    "最後更新",
-    "瀏覽人次",
-    "大小",
-    "收藏次數",
-    "熱度",
-    "人氣",
-    "實驗室到發布",
-    "瀏覽蒐藏比",
-    "距離上次更新",
-    "已發布",
-    "人次發布比",
-]
-
 
 def _load_taiwan_blacklist() -> set[str]:
     """Return a set of world IDs from the Taiwan blacklist if present."""
@@ -77,7 +61,7 @@ def _save_worlds(worlds: List[dict], file_path: Path) -> None:
         file_path.parent.mkdir(parents=True, exist_ok=True)
         wb = Workbook()
         ws = wb.active
-        ws.append(METRIC_COLS)
+        ws.append(["爬取日期"] + METRIC_COLS)
     for w in worlds:
         ws.append(record_row(w))
     wb.save(file_path)

--- a/world_info/scraper/scraper.py
+++ b/world_info/scraper/scraper.py
@@ -19,6 +19,11 @@ from typing import Dict, List, Optional
 import time
 
 try:
+    from world_info.constants import METRIC_COLS
+except ModuleNotFoundError:  # pragma: no cover - package path
+    from constants import METRIC_COLS
+
+try:
     from openpyxl import Workbook, load_workbook  # type: ignore
 except Exception:  # pragma: no cover - optional dependency
     Workbook = None  # type: ignore
@@ -191,23 +196,7 @@ def update_history(worlds: List[dict], threshold: int = 3600) -> Dict[str, List[
 
 def _append_history_table(row: List[object]) -> None:
     """Append a metrics row to ``history_table.xlsx``."""
-    headers = [
-        "爬取日期",
-        "世界名稱",
-        "世界ID",
-        "發布日期",
-        "最後更新",
-        "瀏覽人次",
-        "大小",
-        "收藏次數",
-        "熱度",
-        "人氣",
-        "實驗室到發布",
-        "瀏覽蒐藏比",
-        "距離上次更新",
-        "已發布",
-        "人次發布比",
-    ]
+    headers = ["爬取日期"] + METRIC_COLS
     if Workbook is None or load_workbook is None:
         raise RuntimeError("openpyxl is required to write Excel logs")
     if HISTORY_TABLE.exists():
@@ -223,23 +212,7 @@ def _append_history_table(row: List[object]) -> None:
 
 def _append_excel_row(row: List[object]) -> None:
     """Append a metrics row to ``worlds.xlsx``."""
-    headers = [
-        "爬取日期",
-        "世界名稱",
-        "世界ID",
-        "發布日期",
-        "最後更新",
-        "瀏覽人次",
-        "大小",
-        "收藏次數",
-        "熱度",
-        "人氣",
-        "實驗室到發布",
-        "瀏覽蒐藏比",
-        "距離上次更新",
-        "已發布",
-        "人次發布比",
-    ]
+    headers = ["爬取日期"] + METRIC_COLS
     if Workbook is None or load_workbook is None:
         raise RuntimeError("openpyxl is required to write Excel logs")
     if EXCEL_FILE.exists():


### PR DESCRIPTION
## Summary
- reuse shared `METRIC_COLS` constant in `mode_crawler` and `scraper`
- drop duplicated header lists in favor of `METRIC_COLS`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689942f23378832db3dee8a5e9f05559