### PR TITLE
Handle digit string timestamps in scraper._parse_date

### DIFF
--- a/tests/test_parse_date.py
+++ b/tests/test_parse_date.py
@@ -1,0 +1,22 @@
+import datetime as dt
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "scraper_module",
+    Path(__file__).resolve().parent.parent / "world_info" / "scraper" / "scraper.py",
+)
+scraper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scraper)  # type: ignore
+_parse_date = scraper._parse_date
+
+
+def test_parse_date_numeric_and_digit_string():
+    ts = 1_234_567_890
+    expected = dt.datetime.fromtimestamp(ts, dt.timezone.utc)
+
+    int_dt = _parse_date(ts)
+    float_dt = _parse_date(float(ts))
+    str_dt = _parse_date(str(ts))
+
+    assert int_dt == float_dt == str_dt == expected

--- a/world_info/scraper/scraper.py
+++ b/world_info/scraper/scraper.py
@@ -129,6 +129,8 @@ def _parse_date(value: Optional[str]) -> Optional[dt.datetime]:
         # allow plain dates like "2025/7/12" for manual edits
         if isinstance(value, (int, float)):
             return dt.datetime.fromtimestamp(float(value), dt.timezone.utc)
+        if isinstance(value, str) and value.isdigit():
+            return dt.datetime.fromtimestamp(float(value), dt.timezone.utc)
         if value.endswith("Z"):
             value = value[:-1] + "+00:00"
         if "T" in value:


### PR DESCRIPTION
## Summary
- Parse digit-only string timestamps using float conversion
- Test numeric and digit-string timestamp inputs parse to the same datetime

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689946fa55d0832d9e251b0b3621b68f