### PR TITLE
Handle raw IDs in personal search

### DIFF
--- a/tests/test_search_personal_no_duplicates.py
+++ b/tests/test_search_personal_no_duplicates.py
@@ -80,3 +80,79 @@ def test_search_personal_no_duplicates(monkeypatch):
     ui_module.WorldInfoUI._search_personal(ui)
     assert len(ui.user_tree.get_children()) == 1
 
+
+def test_search_personal_no_duplicates_raw_data(monkeypatch):
+    base = Path(__file__).resolve().parent.parent
+    sys.path.append(str(base))
+    sys.path.append(str(base / "world_info"))
+    from world_info import ui as ui_module
+
+    saved_worlds: list[dict] = []
+    saved_files: list[Path] = []
+    loaded_files: list[Path] = []
+
+    def fake_search_user(user_id, headers):
+        return [{"id": "w1", "name": "World"}]
+
+    def fake_save_worlds(worlds, file):
+        saved_worlds.extend(worlds)
+        saved_files.append(file)
+
+    def fake_update_history(worlds):
+        pass
+
+    def fake_load_history():
+        return {}
+
+    def fake_update_daily_stats(source, worlds):
+        pass
+
+    def fake_load_local_tables(self):
+        path = ui_module.BASE / "scraper" / self.settings.get(
+            "personal_file", ui_module.PERSONAL_FILE.name
+        )
+        loaded_files.append(path)
+        self.user_data = list(saved_worlds)
+        for w in saved_worlds:
+            self.user_tree.insert("", None, values=(w["id"],))
+
+    monkeypatch.setattr(ui_module, "search_user", fake_search_user)
+    monkeypatch.setattr(ui_module, "save_worlds", fake_save_worlds)
+    monkeypatch.setattr(ui_module, "update_history", fake_update_history)
+    monkeypatch.setattr(ui_module, "load_history", fake_load_history)
+    monkeypatch.setattr(ui_module, "update_daily_stats", fake_update_daily_stats)
+
+    class MockTree:
+        def __init__(self):
+            self.items = []
+
+        def get_children(self):
+            return list(self.items)
+
+        def delete(self, item):
+            self.items.remove(item)
+
+        def insert(self, parent, index, values):
+            self.items.append(values)
+
+    ui = types.SimpleNamespace()
+    ui._load_auth_headers = lambda: None
+    ui.settings = {"player_id": "user123", "personal_file": "custom.xlsx"}
+    ui.headers = {}
+    ui.user_tree = MockTree()
+    ui.user_data = []
+    ui.history = {}
+    ui._update_history_options = lambda: None
+    ui.nb = types.SimpleNamespace(select=lambda frame: None)
+    ui.tab_user = types.SimpleNamespace(frame=object())
+    ui._load_local_tables = lambda: fake_load_local_tables(ui)
+
+    ui_module.WorldInfoUI._search_personal(ui)
+    assert len(ui.user_tree.get_children()) == 1
+    expected = ui_module.BASE / "scraper" / "custom.xlsx"
+    assert saved_files == [expected]
+    assert loaded_files == [expected]
+
+    ui_module.WorldInfoUI._search_personal(ui)
+    assert len(ui.user_tree.get_children()) == 1
+

--- a/world_info/ui.py
+++ b/world_info/ui.py
@@ -293,8 +293,16 @@ class WorldInfoUI(tk.Tk):
         for w in worlds:
             w["爬取日期"] = fetch_date
         # remove already recorded worlds so repeated searches don't duplicate rows
-        existing_ids = {w.get("世界ID") for w in self.user_data if w.get("世界ID")}
-        worlds = [w for w in worlds if w.get("id") not in existing_ids]
+        existing_ids = {
+            w.get("id") or w.get("世界ID")
+            for w in self.user_data
+            if w.get("id") or w.get("世界ID")
+        }
+        worlds = [
+            w
+            for w in worlds
+            if (w.get("id") or w.get("世界ID")) not in existing_ids
+        ]
 
         # clear current rows before inserting the refreshed data
         for item in self.user_tree.get_children():


### PR DESCRIPTION
## Summary
- Prevent duplicate personal search entries by recognizing both raw `id` and localized `世界ID` values
- Test that raw API data in `self.user_data` does not create duplicate rows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68994e12b2a0832d9f11d361fd53c8ea