### PR TITLE
feat: generate personal stats prefab

### DIFF
--- a/Assets/WorldInfo/PersonalStatsTemplate.prefab
+++ b/Assets/WorldInfo/PersonalStatsTemplate.prefab
@@ -1,0 +1,9 @@
+# Simplified prefab template for personal stats screen
+Canvas:
+  ScrollRect:
+    Content:
+      CardTemplate:
+        Title:
+          type: TextMeshProUGUI
+        Visits:
+          type: TextMeshProUGUI

--- a/world_info/unity_prefab_generator/GenerateWorldCards.cs
+++ b/world_info/unity_prefab_generator/GenerateWorldCards.cs
@@ -1,24 +1,78 @@
 using System.Collections.Generic;
 using System.IO;
+using TMPro;
 using UnityEditor;
 using UnityEngine;
+#if VRC_SDK_VRCSDK3
+using VRC.SDK3.Components.Image;
+#endif
 
 public class GenerateWorldCards
 {
-    [MenuItem("VRChat/Generate World Cards")]
+    [MenuItem("VRChat/Generate Personal Stats")]
     public static void Generate()
     {
-        string path = Path.Combine(Application.dataPath, "approved_export.json");
+        string path = Path.Combine(Application.dataPath, "user_worlds.json");
         if (!File.Exists(path))
         {
-            Debug.LogError("approved_export.json not found");
+            Debug.LogError("user_worlds.json not found");
             return;
         }
 
         string json = File.ReadAllText(path);
         WorldList wrapper = JsonUtility.FromJson<WorldList>("{\"items\":" + json + "}");
         Debug.Log($"Loaded {wrapper.items.Count} worlds.");
-        // TODO: instantiate prefab templates here
+
+        string templatePath = "Assets/WorldInfo/PersonalStatsTemplate.prefab";
+        GameObject template = AssetDatabase.LoadAssetAtPath<GameObject>(templatePath);
+        if (template == null)
+        {
+            Debug.LogError("Template prefab not found");
+            return;
+        }
+
+        GameObject root = (GameObject)PrefabUtility.InstantiatePrefab(template);
+        Transform content = root.transform.Find("ScrollRect/Content");
+        if (content == null)
+        {
+            Debug.LogError("Content transform missing");
+            Object.DestroyImmediate(root);
+            return;
+        }
+
+        GameObject cardTemplate = content.GetChild(0).gameObject;
+
+        foreach (WorldInfo world in wrapper.items)
+        {
+            GameObject card = Object.Instantiate(cardTemplate, content);
+
+            foreach (TextMeshProUGUI tmp in card.GetComponentsInChildren<TextMeshProUGUI>())
+            {
+                if (tmp.name == "Title")
+                {
+                    tmp.text = world.name;
+                }
+                else if (tmp.name == "Visits")
+                {
+                    tmp.text = world.visits.ToString();
+                }
+            }
+
+#if VRC_SDK_VRCSDK3
+            VRCUrlImageDownloader downloader = card.GetComponentInChildren<VRCUrlImageDownloader>();
+            if (downloader != null && !string.IsNullOrEmpty(world.imageUrl))
+            {
+                downloader.Url = world.imageUrl;
+            }
+#endif
+        }
+
+        Object.DestroyImmediate(cardTemplate);
+
+        string savePath = "Assets/WorldInfo/PersonalStats.prefab";
+        PrefabUtility.SaveAsPrefabAsset(root, savePath);
+        Object.DestroyImmediate(root);
+        AssetDatabase.SaveAssets();
     }
 
     [System.Serializable]


### PR DESCRIPTION
## Summary
- add PersonalStatsTemplate prefab structure for Canvas/ScrollRect Content cards
- extend generator to build PersonalStats prefab from user_worlds.json and fill card info

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a53042eca4832d9e99830c7879f99c